### PR TITLE
Implement dynamic content type management

### DIFF
--- a/TheBackendCmsSolution/Modules/Abstractions/ModuleLoader.cs
+++ b/TheBackendCmsSolution/Modules/Abstractions/ModuleLoader.cs
@@ -6,10 +6,30 @@ public static class ModuleLoader
 {
     public static IEnumerable<ICmsModule> DiscoverModules()
     {
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
+
+        // Ensure module assemblies are loaded so they can be discovered even if
+        // no types have been referenced yet.
+        foreach (var path in Directory.EnumerateFiles(AppContext.BaseDirectory, "TheBackendCmsSolution.Modules.*.dll"))
+        {
+            try
+            {
+                var name = AssemblyName.GetAssemblyName(path);
+                if (!assemblies.Any(a => a.GetName().Name == name.Name))
+                {
+                    assemblies.Add(Assembly.Load(name));
+                }
+            }
+            catch
+            {
+                // Ignore load failures so one bad assembly does not prevent startup
+            }
+        }
+
         var moduleTypes = assemblies
             .SelectMany(a => a.GetTypes())
             .Where(t => typeof(ICmsModule).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
+
         return moduleTypes.Select(t => (ICmsModule)Activator.CreateInstance(t)!);
     }
 }

--- a/TheBackendCmsSolution/Modules/Content/ContentModule.cs
+++ b/TheBackendCmsSolution/Modules/Content/ContentModule.cs
@@ -59,6 +59,41 @@ public class ContentModule : ICmsModule
             return await db.ContentTypes.ToListAsync();
         });
 
+        group.MapGet("/content-types/{id:guid}", async (Guid id, ContentDbContext db, ILogger<ContentModule> logger) =>
+        {
+            var ct = await db.ContentTypes.FindAsync(id);
+            if (ct is null)
+            {
+                logger.LogWarning("Content type {Id} not found", id);
+                return Results.NotFound();
+            }
+            return Results.Ok(ct);
+        });
+
+        group.MapPut("/content-types/{id:guid}", async (Guid id, ContentTypeDto dto, ContentDbContext db, ILogger<ContentModule> logger) =>
+        {
+            var validationErrors = ValidateDto(dto, logger);
+            if (validationErrors != null)
+            {
+                return Results.BadRequest(validationErrors);
+            }
+
+            var existing = await db.ContentTypes.FindAsync(id);
+            if (existing is null)
+            {
+                logger.LogWarning("Content type {Id} not found for update", id);
+                return Results.NotFound();
+            }
+
+            existing.Name = dto.Name;
+            existing.DisplayName = dto.DisplayName;
+            existing.Fields = dto.Fields;
+
+            await db.SaveChangesAsync();
+            logger.LogInformation("Updated content type {Id}", id);
+            return Results.Ok(existing);
+        });
+
         group.MapGet("/content", async (ContentDbContext db, ILogger<ContentModule> logger) =>
         {
             logger.LogInformation("Retrieving all content items");

--- a/TheBackendCmsSolution/Modules/Content/ContentModule.cs
+++ b/TheBackendCmsSolution/Modules/Content/ContentModule.cs
@@ -94,6 +94,20 @@ public class ContentModule : ICmsModule
             return Results.Ok(existing);
         });
 
+        group.MapDelete("/content-types/{id:guid}", async (Guid id, ContentDbContext db, ILogger<ContentModule> logger) =>
+        {
+            var ct = await db.ContentTypes.FindAsync(id);
+            if (ct is null)
+            {
+                logger.LogWarning("Content type {Id} not found for deletion", id);
+                return Results.NotFound();
+            }
+            db.ContentTypes.Remove(ct);
+            await db.SaveChangesAsync();
+            logger.LogInformation("Deleted content type {Id}", id);
+            return Results.NoContent();
+        });
+
         group.MapGet("/content", async (ContentDbContext db, ILogger<ContentModule> logger) =>
         {
             logger.LogInformation("Retrieving all content items");

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Layout/NavMenu.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Layout/NavMenu.razor
@@ -25,5 +25,10 @@
                 <span class="bi bi-list-nested" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="admin/content-types">
+                <span class="bi bi-collection" aria-hidden="true"></span> Content Types
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentTypes.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentTypes.razor
@@ -1,0 +1,148 @@
+@page "/admin/content-types"
+@rendermode InteractiveServer
+@inject ContentApiClient Api
+
+<h1>Content Types</h1>
+
+@if (contentTypes is null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Display Name</th>
+                <th>Fields</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var ct in contentTypes)
+        {
+            <tr>
+                <td>@ct.Name</td>
+                <td>@ct.DisplayName</td>
+                <td>@string.Join(", ", ct.Fields.Keys)</td>
+                <td><button class="btn btn-sm btn-secondary" @onclick="() => Edit(ct)">Edit</button></td>
+            </tr>
+        }
+        </tbody>
+    </table>
+
+    <hr />
+
+    <h3>@(editingId is null ? "Create" : "Edit") Content Type</h3>
+    <EditForm Model="dto" OnValidSubmit="SaveAsync">
+        <DataAnnotationsValidator />
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <InputText class="form-control" @bind-Value="dto.Name" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Display Name</label>
+            <InputText class="form-control" @bind-Value="dto.DisplayName" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Fields</label>
+            @foreach (var field in fields)
+            {
+                <div class="input-group mb-1">
+                    <InputText class="form-control" placeholder="Field name" @bind-Value="field.Name" />
+                    <InputText class="form-control" placeholder="Type" @bind-Value="field.Type" />
+                    <button type="button" class="btn btn-danger" @onclick="() => RemoveField(field)">X</button>
+                </div>
+            }
+            <button type="button" class="btn btn-secondary" @onclick="AddField">Add Field</button>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        @if (editingId is not null)
+        {
+            <button type="button" class="btn btn-link" @onclick="CancelEdit">Cancel</button>
+        }
+    </EditForm>
+}
+
+@code {
+    private List<ContentTypeResponse>? contentTypes;
+    private ContentTypeDtoModel dto = new();
+    private readonly List<FieldModel> fields = [];
+    private Guid? editingId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        contentTypes = await Api.GetContentTypesAsync();
+    }
+
+    private void AddField()
+    {
+        fields.Add(new FieldModel());
+    }
+
+    private void RemoveField(FieldModel field)
+    {
+        fields.Remove(field);
+    }
+
+    private async Task SaveAsync()
+    {
+        dto.Fields = fields.ToDictionary(f => f.Name, f => (object)f.Type);
+        if (editingId is null)
+        {
+            await Api.CreateContentTypeAsync(dto.ToDto());
+        }
+        else
+        {
+            await Api.UpdateContentTypeAsync(editingId.Value, dto.ToDto());
+        }
+        ResetForm();
+        await LoadAsync();
+    }
+
+    private void Edit(ContentTypeResponse ct)
+    {
+        editingId = ct.Id;
+        dto = new ContentTypeDtoModel { Name = ct.Name, DisplayName = ct.DisplayName };
+        fields.Clear();
+        foreach (var kv in ct.Fields)
+        {
+            fields.Add(new FieldModel { Name = kv.Key, Type = kv.Value?.ToString() ?? "" });
+        }
+    }
+
+    private void CancelEdit()
+    {
+        ResetForm();
+    }
+
+    private void ResetForm()
+    {
+        editingId = null;
+        dto = new ContentTypeDtoModel();
+        fields.Clear();
+    }
+
+    class FieldModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+    }
+
+    class ContentTypeDtoModel
+    {
+        [Required]
+        public string Name { get; set; } = string.Empty;
+        [Required]
+        public string DisplayName { get; set; } = string.Empty;
+        public Dictionary<string, object> Fields { get; set; } = new();
+
+        public ContentTypeDto ToDto() => new(Name, DisplayName, Fields);
+    }
+}

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentTypes.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentTypes.razor
@@ -26,7 +26,10 @@ else
                 <td>@ct.Name</td>
                 <td>@ct.DisplayName</td>
                 <td>@string.Join(", ", ct.Fields.Keys)</td>
-                <td><button class="btn btn-sm btn-secondary" @onclick="() => Edit(ct)">Edit</button></td>
+                <td>
+                    <button class="btn btn-sm btn-secondary me-1" @onclick="() => Edit(ct)">Edit</button>
+                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteAsync(ct.Id)">Delete</button>
+                </td>
             </tr>
         }
         </tbody>
@@ -103,6 +106,12 @@ else
             await Api.UpdateContentTypeAsync(editingId.Value, dto.ToDto());
         }
         ResetForm();
+        await LoadAsync();
+    }
+
+    private async Task DeleteAsync(Guid id)
+    {
+        await Api.DeleteContentTypeAsync(id);
         await LoadAsync();
     }
 

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
@@ -9,3 +9,4 @@
 @using Microsoft.JSInterop
 @using TheBackendCmsSolution.Web
 @using TheBackendCmsSolution.Web.Components
+@using System.ComponentModel.DataAnnotations

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/ContentApiClient.cs
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/ContentApiClient.cs
@@ -1,0 +1,30 @@
+using System.Net.Http.Json;
+
+namespace TheBackendCmsSolution.Web;
+
+public class ContentApiClient(HttpClient httpClient)
+{
+    public async Task<List<ContentTypeResponse>> GetContentTypesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<ContentTypeResponse>>("/content-types", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<ContentTypeResponse?> GetContentTypeAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await httpClient.GetFromJsonAsync<ContentTypeResponse>($"/content-types/{id}", cancellationToken);
+    }
+
+    public async Task CreateContentTypeAsync(ContentTypeDto dto, CancellationToken cancellationToken = default)
+    {
+        await httpClient.PostAsJsonAsync("/content-types", dto, cancellationToken);
+    }
+
+    public async Task UpdateContentTypeAsync(Guid id, ContentTypeDto dto, CancellationToken cancellationToken = default)
+    {
+        await httpClient.PutAsJsonAsync($"/content-types/{id}", dto, cancellationToken);
+    }
+}
+
+public record ContentTypeDto(string Name, string DisplayName, Dictionary<string, object> Fields);
+public record ContentTypeResponse(Guid Id, string Name, string DisplayName, Dictionary<string, object> Fields);

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/ContentApiClient.cs
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/ContentApiClient.cs
@@ -6,23 +6,45 @@ public class ContentApiClient(HttpClient httpClient)
 {
     public async Task<List<ContentTypeResponse>> GetContentTypesAsync(CancellationToken cancellationToken = default)
     {
-        var result = await httpClient.GetFromJsonAsync<List<ContentTypeResponse>>("/content-types", cancellationToken);
-        return result ?? [];
+        try
+        {
+            var result = await httpClient.GetFromJsonAsync<List<ContentTypeResponse>>("/content-types", cancellationToken);
+            return result ?? [];
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return [];
+        }
     }
 
     public async Task<ContentTypeResponse?> GetContentTypeAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        return await httpClient.GetFromJsonAsync<ContentTypeResponse>($"/content-types/{id}", cancellationToken);
+        try
+        {
+            return await httpClient.GetFromJsonAsync<ContentTypeResponse>($"/content-types/{id}", cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
     }
 
     public async Task CreateContentTypeAsync(ContentTypeDto dto, CancellationToken cancellationToken = default)
     {
-        await httpClient.PostAsJsonAsync("/content-types", dto, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("/content-types", dto, cancellationToken);
+        response.EnsureSuccessStatusCode();
     }
 
     public async Task UpdateContentTypeAsync(Guid id, ContentTypeDto dto, CancellationToken cancellationToken = default)
     {
-        await httpClient.PutAsJsonAsync($"/content-types/{id}", dto, cancellationToken);
+        var response = await httpClient.PutAsJsonAsync($"/content-types/{id}", dto, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteContentTypeAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.DeleteAsync($"/content-types/{id}", cancellationToken);
+        response.EnsureSuccessStatusCode();
     }
 }
 

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Program.cs
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Program.cs
@@ -19,6 +19,11 @@ builder.Services.AddHttpClient<WeatherApiClient>(client =>
         client.BaseAddress = new("https+http://apiservice");
     });
 
+builder.Services.AddHttpClient<ContentApiClient>(client =>
+    {
+        client.BaseAddress = new("https+http://apiservice");
+    });
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/appsettings.Development.json
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "DetailedErrors": true
 }

--- a/TheBackendCmsSolution/docs/api.md
+++ b/TheBackendCmsSolution/docs/api.md
@@ -141,6 +141,29 @@ Response (204 No Content): If successful.
 Error (404 Not Found): If the ID doesn’t exist.
 Example:curl -X DELETE http://localhost:7309/content/123e4567-e89b-12d3-a456-426614174000
 
+Content Types
+POST /content-types
+Creates a new content type.
+
+Request:
+{
+  "Name": "blogpost",
+  "DisplayName": "Blog Post",
+  "Fields": {
+    "Body": "string",
+    "Tags": "string[]"
+  }
+}
+
+GET /content-types
+Retrieves all content types.
+
+GET /content-types/{id}
+Retrieves a content type by ID.
+
+PUT /content-types/{id}
+Updates an existing content type.
+
 
 
 Notes

--- a/TheBackendCmsSolution/docs/api.md
+++ b/TheBackendCmsSolution/docs/api.md
@@ -164,6 +164,9 @@ Retrieves a content type by ID.
 PUT /content-types/{id}
 Updates an existing content type.
 
+DELETE /content-types/{id}
+Deletes a content type.
+
 
 
 Notes


### PR DESCRIPTION
## Summary
- add API endpoints to get/update content types
- add Web `ContentApiClient`
- create admin page for listing and editing content types
- register new HTTP client and add nav link
- document content type endpoints

## Testing
- `dotnet build TheBackendCmsSolution/TheBackendCmsSolution.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a891b24e08324a894533aa1a2d086