### PR TITLE
Add dynamic admin UI pages

### DIFF
--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/FieldEditors/DynamicFieldEditor.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/FieldEditors/DynamicFieldEditor.razor
@@ -1,0 +1,34 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+
+<div class="mb-3">
+    <label class="form-label">@FieldName</label>
+    @if (FieldType == "string[]")
+    {
+        <InputTextArea class="form-control" @bind-Value="StringArrayValue" />
+        <div class="form-text">Enter one value per line</div>
+    }
+    else
+    {
+        <InputText class="form-control" @bind-Value="StringValue" />
+    }
+</div>
+
+@code {
+    [Parameter] public string FieldName { get; set; } = string.Empty;
+    [Parameter] public string? FieldType { get; set; } = "string";
+    [Parameter] public object? Value { get; set; }
+    [Parameter] public EventCallback<object?> ValueChanged { get; set; }
+
+    private string StringValue
+    {
+        get => Value?.ToString() ?? string.Empty;
+        set => ValueChanged.InvokeAsync(value);
+    }
+
+    private string StringArrayValue
+    {
+        get => Value is IEnumerable<string> arr ? string.Join("\n", arr) : (Value?.ToString() ?? string.Empty);
+        set => ValueChanged.InvokeAsync(value.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+    }
+}

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Layout/NavMenu.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Layout/NavMenu.razor
@@ -30,5 +30,15 @@
                 <span class="bi bi-collection" aria-hidden="true"></span> Content Types
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="admin/content-items">
+                <span class="bi bi-card-text" aria-hidden="true"></span> Content Items
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="admin/modules">
+                <span class="bi bi-puzzle" aria-hidden="true"></span> Modules
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
@@ -1,0 +1,175 @@
+@page "/admin/content-items"
+@rendermode InteractiveServer
+@inject ContentApiClient Api
+
+<h1>Content Items</h1>
+
+@if (items is null || contentTypes is null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Content Type</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var item in items)
+        {
+            <tr>
+                <td>@item.Title</td>
+                <td>@item.ContentType.DisplayName</td>
+                <td>
+                    <button class="btn btn-sm btn-secondary me-1" @onclick="() => Edit(item)">Edit</button>
+                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteAsync(item.Id)">Delete</button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+
+    <hr />
+    <h3>@(editingId is null ? "Create" : "Edit") Content Item</h3>
+    <EditForm Model="model" OnValidSubmit="SaveAsync">
+        <DataAnnotationsValidator />
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <InputText class="form-control" @bind-Value="model.Title" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Content Type</label>
+            <select class="form-select" @bind="model.ContentTypeId" @onchange="ContentTypeChanged">
+                <option value="">-- Select --</option>
+                @foreach (var ct in contentTypes)
+                {
+                    <option value="@ct.Id">@ct.DisplayName</option>
+                }
+            </select>
+        </div>
+        @if (currentContentType is not null)
+        {
+            @foreach (var field in currentContentType.Fields)
+            {
+                <DynamicFieldEditor FieldName="@field.Key" FieldType="@field.Value?.ToString()" Value="GetFieldValue(field.Key)" ValueChanged="v => SetFieldValue(field.Key, v)" />
+            }
+        }
+        <button type="submit" class="btn btn-primary">Save</button>
+        @if (editingId is not null)
+        {
+            <button type="button" class="btn btn-link" @onclick="CancelEdit">Cancel</button>
+        }
+    </EditForm>
+}
+
+@code {
+    private List<ContentItemResponse>? items;
+    private List<ContentTypeResponse>? contentTypes;
+    private ContentItemDtoModel model = new();
+    private Guid? editingId;
+    private ContentTypeResponse? currentContentType;
+    private readonly Dictionary<string, object?> fieldValues = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        contentTypes = await Api.GetContentTypesAsync();
+        items = await Api.GetContentItemsAsync();
+    }
+
+    private object? GetFieldValue(string name) => fieldValues.TryGetValue(name, out var v) ? v : null;
+    private Task SetFieldValue(string name, object? value)
+    {
+        fieldValues[name] = value;
+        return Task.CompletedTask;
+    }
+
+    private async Task SaveAsync()
+    {
+        model.Fields = new(fieldValues);
+        if (editingId is null)
+        {
+            await Api.CreateContentItemAsync(model.ToDto());
+        }
+        else
+        {
+            await Api.UpdateContentItemAsync(editingId.Value, model.ToDto());
+        }
+        ResetForm();
+        await LoadAsync();
+    }
+
+    private async Task DeleteAsync(Guid id)
+    {
+        await Api.DeleteContentItemAsync(id);
+        await LoadAsync();
+    }
+
+    private void Edit(ContentItemResponse item)
+    {
+        editingId = item.Id;
+        model = new ContentItemDtoModel { Title = item.Title, ContentTypeId = item.ContentTypeId };
+        currentContentType = contentTypes!.First(ct => ct.Id == item.ContentTypeId);
+        fieldValues.Clear();
+        foreach (var kv in item.Fields)
+        {
+            fieldValues[kv.Key] = ConvertFieldValue(kv.Value);
+        }
+    }
+
+    private void CancelEdit()
+    {
+        ResetForm();
+    }
+
+    private void ResetForm()
+    {
+        editingId = null;
+        model = new ContentItemDtoModel();
+        fieldValues.Clear();
+        currentContentType = null;
+    }
+
+    private void ContentTypeChanged(ChangeEventArgs e)
+    {
+        if (Guid.TryParse(e.Value?.ToString(), out var id))
+        {
+            currentContentType = contentTypes?.FirstOrDefault(ct => ct.Id == id);
+        }
+    }
+
+    private static object? ConvertFieldValue(object? value)
+    {
+        if (value is System.Text.Json.JsonElement el)
+        {
+            if (el.ValueKind == System.Text.Json.JsonValueKind.Array)
+            {
+                return el.EnumerateArray().Select(v => v.GetString() ?? string.Empty).ToArray();
+            }
+            if (el.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                return el.GetString();
+            }
+            return el.ToString();
+        }
+        return value;
+    }
+
+    class ContentItemDtoModel
+    {
+        [Required]
+        public string Title { get; set; } = string.Empty;
+        [Required]
+        public Guid ContentTypeId { get; set; }
+        public Dictionary<string, object?> Fields { get; set; } = new();
+        public ContentItemDto ToDto() => new(Title, ContentTypeId, new Dictionary<string, object>(Fields));
+    }
+}

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
@@ -43,7 +43,7 @@ else
         </div>
         <div class="mb-3">
             <label class="form-label">Content Type</label>
-            <select class="form-select" @bind="model.ContentTypeId" @onchange="ContentTypeChanged">
+            <select class="form-select" @bind="model.ContentTypeId" @bind:after="ContentTypeChanged">
                 <option value="">-- Select --</option>
                 @foreach (var ct in contentTypes)
                 {

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
@@ -138,12 +138,9 @@ else
         currentContentType = null;
     }
 
-    private void ContentTypeChanged(ChangeEventArgs e)
+    private void ContentTypeChanged()
     {
-        if (Guid.TryParse(e.Value?.ToString(), out var id))
-        {
-            currentContentType = contentTypes?.FirstOrDefault(ct => ct.Id == id);
-        }
+        currentContentType = contentTypes?.FirstOrDefault(ct => ct.Id == model.ContentTypeId);
     }
 
     private static object? ConvertFieldValue(object? value)

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/Modules.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/Modules.razor
@@ -1,0 +1,21 @@
+@page "/admin/modules"
+@rendermode InteractiveServer
+@using TheBackendCmsSolution.Modules.Abstractions
+
+<h1>Modules</h1>
+
+<ul>
+@foreach (var module in modules)
+{
+    <li>@module</li>
+}
+</ul>
+
+@code {
+    private List<string> modules = new();
+
+    protected override void OnInitialized()
+    {
+        modules = ModuleLoader.DiscoverModules().Select(m => m.GetType().Name).ToList();
+    }
+}

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
@@ -9,4 +9,5 @@
 @using Microsoft.JSInterop
 @using TheBackendCmsSolution.Web
 @using TheBackendCmsSolution.Web.Components
+@using TheBackendCmsSolution.Modules.Abstractions
 @using System.ComponentModel.DataAnnotations

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
@@ -9,5 +9,6 @@
 @using Microsoft.JSInterop
 @using TheBackendCmsSolution.Web
 @using TheBackendCmsSolution.Web.Components
+@using TheBackendCmsSolution.Web.Components.FieldEditors
 @using TheBackendCmsSolution.Modules.Abstractions
 @using System.ComponentModel.DataAnnotations

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/ContentApiClient.cs
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/ContentApiClient.cs
@@ -46,7 +46,53 @@ public class ContentApiClient(HttpClient httpClient)
         var response = await httpClient.DeleteAsync($"/content-types/{id}", cancellationToken);
         response.EnsureSuccessStatusCode();
     }
+
+    public async Task<List<ContentItemResponse>> GetContentItemsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await httpClient.GetFromJsonAsync<List<ContentItemResponse>>("/content", cancellationToken);
+            return result ?? [];
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return [];
+        }
+    }
+
+    public async Task<ContentItemResponse?> GetContentItemAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await httpClient.GetFromJsonAsync<ContentItemResponse>($"/content/{id}", cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task CreateContentItemAsync(ContentItemDto dto, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("/content", dto, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task UpdateContentItemAsync(Guid id, ContentItemDto dto, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PutAsJsonAsync($"/content/{id}", dto, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteContentItemAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.DeleteAsync($"/content/{id}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
 }
 
 public record ContentTypeDto(string Name, string DisplayName, Dictionary<string, object> Fields);
 public record ContentTypeResponse(Guid Id, string Name, string DisplayName, Dictionary<string, object> Fields);
+public record ContentTypeSummary(string Name, string DisplayName);
+public record ContentItemDto(string Title, Guid ContentTypeId, Dictionary<string, object> Fields);
+public record ContentItemResponse(Guid Id, string Title, Guid ContentTypeId, ContentTypeSummary ContentType, Dictionary<string, object> Fields, DateTime CreatedAt, DateTime? UpdatedAt);

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/TheBackendCmsSolution.Web.csproj
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/TheBackendCmsSolution.Web.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TheBackendCmsSolution.ServiceDefaults\TheBackendCmsSolution.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Modules\Abstractions\TheBackendCmsSolution.Modules.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/TheBackendCmsSolution.Web.csproj
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/TheBackendCmsSolution.Web.csproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <ProjectReference Include="..\TheBackendCmsSolution.ServiceDefaults\TheBackendCmsSolution.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Modules\Abstractions\TheBackendCmsSolution.Modules.Abstractions.csproj" />
+    <ProjectReference Include="..\Modules\Content\TheBackendCmsSolution.Modules.Content.csproj" />
+    <ProjectReference Include="..\Modules\Taxonomy\TheBackendCmsSolution.Modules.Taxonomy.csproj" />
+    <ProjectReference Include="..\Modules\Users\TheBackendCmsSolution.Modules.Users.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add HTTP calls for content items in `ContentApiClient`
- implement `DynamicFieldEditor` component
- create admin pages for content items and modules
- expose links in the nav menu
- import module abstractions for Blazor components

## Testing
- `dotnet build TheBackendCmsSolution/TheBackendCmsSolution.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8e41d01c832487005a9be2e2c386