### PR TITLE
Improve README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # TheBackend-CMS
-TheBackend-CMS
+
+A modular Content Management System built with **.NET 9** and **.NET Aspire**.
+The repository contains the main solution `TheBackendCmsSolution` which hosts
+several projects and modules.
+
+## Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) (preview)
+- Docker Desktop for running PostgreSQL containers
+- Git
+- Optional: Visual Studio 2022 or VS Code
+
+## Quick Setup
+
+Clone the repository and restore dependencies:
+
+```bash
+git clone https://github.com/trajkovdimitar/TheBackend-CMS.git
+cd TheBackend-CMS/TheBackendCmsSolution
+dotnet workload install aspire    # only needed once
+dotnet restore
+```
+
+## Building and Running
+
+Ensure Docker Desktop is running, then start the AppHost which launches the
+Aspire dashboard, ApiService, Web frontend and the PostgreSQL databases:
+
+```bash
+dotnet run --project TheBackendCmsSolution.AppHost
+```
+
+The dashboard is available at `http://localhost:18888` (port may vary) and the
+ApiService listens on a dynamic port displayed in the dashboard.
+
+## Projects Overview
+
+- **TheBackendCmsSolution.AppHost** – orchestrates all services using .NET
+  Aspire.
+- **TheBackendCmsSolution.ApiService** – minimal API exposing CMS endpoints.
+- **TheBackendCmsSolution.Web** – web front‑end (work in progress).
+- **TheBackendCmsSolution.ServiceDefaults** – shared configuration such as
+  health checks and OpenTelemetry.
+- **Modules/** – pluggable modules (Content, Tenants, Taxonomy, Users, …).
+- **docs/** – additional documentation and guides.
+
+See `TheBackendCmsSolution/README.md` and `docs/index.md` for detailed guides
+and API documentation.

--- a/TheBackendCmsSolution/docs/index.md
+++ b/TheBackendCmsSolution/docs/index.md
@@ -1,12 +1,32 @@
-TheBackend-CMS Documentation
-Welcome to the detailed documentation for TheBackend-CMS, a cloud-agnostic CMS built with .NET 9 and .NET Aspire.
-Planned Guides
+# TheBackend-CMS Documentation
 
-Architecture Overview: Structure of the CMS, including modularity and multi-tenancy.
-Development Setup: In-depth setup for contributors.
-API Reference: Documentation for CmsCore endpoints.
-Deployment: Deploying to cloud providers (AWS, Azure, Google Cloud) or on-premises.
-Contributing: How to contribute code, docs, or issues.
+Welcome to the detailed documentation for **TheBackend-CMS**, a cloud-agnostic
+CMS built with .NET&nbsp;9 and .NET Aspire.
 
-Getting Started
-For quick setup, see the README.
+## Guides
+
+### Architecture Overview
+An upcoming guide describing the solution layout and how the AppHost starts
+each project. It will also cover the modular system and planned multi-tenancy
+features.
+
+### Development Setup
+Step-by-step instructions for preparing a development environment. This guide
+explains installing prerequisites, restoring packages and running the AppHost
+for local development.
+
+### API Reference
+Detailed documentation of the CMS endpoints. See [api.md](api.md) for the
+current set of routes and examples.
+
+### Deployment
+Instructions for deploying the CMS to various cloud providers or on-premises
+infrastructure. This will outline building container images and configuring
+environment variables.
+
+### Contributing
+Guidelines for contributing code, documentation or filing issues.
+
+## Getting Started
+
+For a quick start see the repository `README.md`.


### PR DESCRIPTION
## Summary
- expand root `README.md` with setup instructions, AppHost build/run steps and project overview
- flesh out `docs/index.md` with descriptions of the planned guides

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b00cdebb48324adc4b8f5c79d2748