### PR TITLE
Implement tenant CRUD API

### DIFF
--- a/TheBackendCmsSolution/Modules/Tenants/Services/ITenantStore.cs
+++ b/TheBackendCmsSolution/Modules/Tenants/Services/ITenantStore.cs
@@ -1,0 +1,12 @@
+using TheBackendCmsSolution.Modules.Tenants.Models;
+
+namespace TheBackendCmsSolution.Modules.Tenants.Services;
+
+public interface ITenantStore
+{
+    Task<List<Tenant>> GetAllAsync();
+    Task<Tenant?> GetAsync(Guid id);
+    Task<Tenant> CreateAsync(Tenant tenant);
+    Task<bool> UpdateAsync(Guid id, Tenant tenant);
+    Task<bool> DeleteAsync(Guid id);
+}

--- a/TheBackendCmsSolution/Modules/Tenants/Services/TenantStore.cs
+++ b/TheBackendCmsSolution/Modules/Tenants/Services/TenantStore.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+using TheBackendCmsSolution.Modules.Tenants.Data;
+using TheBackendCmsSolution.Modules.Tenants.Models;
+
+namespace TheBackendCmsSolution.Modules.Tenants.Services;
+
+public class TenantStore : ITenantStore
+{
+    private readonly TenantDbContext _db;
+
+    public TenantStore(TenantDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<List<Tenant>> GetAllAsync() => await _db.Tenants.AsNoTracking().ToListAsync();
+
+    public async Task<Tenant?> GetAsync(Guid id) => await _db.Tenants.FindAsync(id);
+
+    public async Task<Tenant> CreateAsync(Tenant tenant)
+    {
+        tenant.Id = Guid.NewGuid();
+        _db.Tenants.Add(tenant);
+        await _db.SaveChangesAsync();
+        return tenant;
+    }
+
+    public async Task<bool> UpdateAsync(Guid id, Tenant tenant)
+    {
+        var existing = await _db.Tenants.FindAsync(id);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        existing.Name = tenant.Name;
+        existing.Host = tenant.Host;
+        existing.UrlPrefix = tenant.UrlPrefix;
+        existing.ConnectionString = tenant.ConnectionString;
+
+        await _db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> DeleteAsync(Guid id)
+    {
+        var existing = await _db.Tenants.FindAsync(id);
+        if (existing is null)
+        {
+            return false;
+        }
+        _db.Tenants.Remove(existing);
+        await _db.SaveChangesAsync();
+        return true;
+    }
+}

--- a/TheBackendCmsSolution/Modules/Tenants/TenancyModule.cs
+++ b/TheBackendCmsSolution/Modules/Tenants/TenancyModule.cs
@@ -28,19 +28,56 @@ public class TenancyModule : ICmsModule
         });
         services.AddScoped<ITenantResolver, TenantResolver>();
         services.AddScoped<ITenantAccessor, TenantAccessor>();
+        services.AddScoped<ITenantStore, TenantStore>();
     }
 
     public void MapRoutes(IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/tenants");
-        group.MapGet("/", async (TenantDbContext db) => await db.Tenants.ToListAsync());
-        group.MapPost("/", async (Tenant tenant, TenantDbContext db, ILogger<TenancyModule> logger) =>
+
+        group.MapGet("/", async (ITenantStore store) => await store.GetAllAsync());
+
+        group.MapGet("/{id:guid}", async (Guid id, ITenantStore store, ILogger<TenancyModule> logger) =>
         {
-            tenant.Id = Guid.NewGuid();
-            db.Tenants.Add(tenant);
-            await db.SaveChangesAsync();
-            logger.LogInformation("Created tenant {Id}", tenant.Id);
-            return Results.Created($"/tenants/{tenant.Id}", tenant);
+            var tenant = await store.GetAsync(id);
+            if (tenant is null)
+            {
+                logger.LogWarning("Tenant {Id} not found", id);
+                return Results.NotFound();
+            }
+            return Results.Ok(tenant);
+        });
+
+        group.MapPost("/", async (Tenant tenant, ITenantStore store, ILogger<TenancyModule> logger) =>
+        {
+            var created = await store.CreateAsync(tenant);
+            logger.LogInformation("Created tenant {Id}", created.Id);
+            return Results.Created($"/tenants/{created.Id}", created);
+        });
+
+        group.MapPut("/{id:guid}", async (Guid id, Tenant tenant, ITenantStore store, ILogger<TenancyModule> logger) =>
+        {
+            var updated = await store.UpdateAsync(id, tenant);
+            if (!updated)
+            {
+                logger.LogWarning("Tenant {Id} not found for update", id);
+                return Results.NotFound();
+            }
+            logger.LogInformation("Updated tenant {Id}", id);
+            tenant.Id = id;
+            return Results.Ok(tenant);
+        });
+
+        group.MapDelete("/{id:guid}", async (Guid id, ITenantStore store, ILogger<TenancyModule> logger) =>
+        {
+            var removed = await store.DeleteAsync(id);
+            if (!removed)
+            {
+                logger.LogWarning("Tenant {Id} not found for deletion", id);
+                return Results.NotFound();
+            }
+            logger.LogInformation("Deleted tenant {Id}", id);
+            return Results.NoContent();
         });
     }
 


### PR DESCRIPTION
## Summary
- add TenantStore service with basic CRUD operations
- register store in TenancyModule
- expose GET/POST/PUT/DELETE endpoints for tenants

## Testing
- `dotnet build TheBackendCmsSolution/TheBackendCmsSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b00ca925c83249c5568da336547ef