### PR TITLE
Add OpenId server module and login

### DIFF
--- a/TheBackendCmsSolution/Modules/OpenId/AuthDbContextFactory.cs
+++ b/TheBackendCmsSolution/Modules/OpenId/AuthDbContextFactory.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using TheBackendCmsSolution.Modules.OpenId.Data;
+
+namespace TheBackendCmsSolution.Modules.OpenId;
+
+public class AuthDbContextFactory : IDesignTimeDbContextFactory<AuthDbContext>
+{
+    public AuthDbContext CreateDbContext(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<AuthDbContext>();
+        var connectionString = configuration.GetConnectionString("authdb") ??
+            "Host=localhost;Port=5434;Database=authdb;Username=postgres;Password=postgres";
+        optionsBuilder.UseNpgsql(connectionString);
+        optionsBuilder.UseOpenIddict();
+        return new AuthDbContext(optionsBuilder.Options);
+    }
+}

--- a/TheBackendCmsSolution/Modules/OpenId/Data/AuthDbContext.cs
+++ b/TheBackendCmsSolution/Modules/OpenId/Data/AuthDbContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using OpenIddict.EntityFrameworkCore.Models;
+using TheBackendCmsSolution.Modules.OpenId.Models;
+
+namespace TheBackendCmsSolution.Modules.OpenId.Data;
+
+public class AuthDbContext : DbContext
+{
+    public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options) { }
+
+    public DbSet<AppUser> Users => Set<AppUser>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+        builder.UseOpenIddict();
+    }
+}

--- a/TheBackendCmsSolution/Modules/OpenId/Models/AppUser.cs
+++ b/TheBackendCmsSolution/Modules/OpenId/Models/AppUser.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TheBackendCmsSolution.Modules.OpenId.Models;
+
+public class AppUser
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public string UserName { get; set; } = string.Empty;
+
+    [Required]
+    public string PasswordHash { get; set; } = string.Empty;
+}

--- a/TheBackendCmsSolution/Modules/OpenId/OpenIdModule.cs
+++ b/TheBackendCmsSolution/Modules/OpenId/OpenIdModule.cs
@@ -1,0 +1,102 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
+using TheBackendCmsSolution.Modules.Abstractions;
+using TheBackendCmsSolution.Modules.OpenId.Data;
+using TheBackendCmsSolution.Modules.OpenId.Models;
+
+namespace TheBackendCmsSolution.Modules.OpenId;
+
+public class OpenIdModule : ICmsModule
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<AuthDbContext>((sp, options) =>
+        {
+            var connectionString = configuration.GetConnectionString("authdb") ??
+                "Host=localhost;Port=5434;Database=authdb;Username=postgres;Password=postgres";
+            options.UseNpgsql(connectionString);
+            options.UseOpenIddict();
+        });
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        }).AddCookie();
+
+        services.AddOpenIddict()
+            .AddCore(options =>
+            {
+                options.UseEntityFrameworkCore()
+                       .UseDbContext<AuthDbContext>();
+            })
+            .AddServer(options =>
+            {
+                options.SetTokenEndpointUris("/connect/token");
+                options.AllowPasswordFlow();
+                options.AcceptAnonymousClients();
+                options.AddDevelopmentEncryptionCertificate()
+                       .AddDevelopmentSigningCertificate();
+                options.UseAspNetCore()
+                       .EnableTokenEndpointPassthrough();
+            })
+            .AddValidation(options =>
+            {
+                options.UseLocalServer();
+                options.UseAspNetCore();
+            });
+    }
+
+    public void MapRoutes(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/auth");
+        group.MapPost("/register", RegisterAsync);
+        group.MapPost("/login", LoginAsync);
+    }
+
+    private static async Task<IResult> RegisterAsync(AppUser user, AuthDbContext db)
+    {
+        if (await db.Users.AnyAsync(u => u.UserName == user.UserName))
+        {
+            return Results.BadRequest(new { error = "User exists" });
+        }
+        user.Id = Guid.NewGuid();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword(user.PasswordHash);
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+        return Results.Ok();
+    }
+
+    private static async Task<IResult> LoginAsync(HttpContext httpContext, AuthDbContext db)
+    {
+        var form = await httpContext.Request.ReadFormAsync();
+        var username = form["username"].ToString();
+        var password = form["password"].ToString();
+        var user = await db.Users.FirstOrDefaultAsync(u => u.UserName == username);
+        if (user is null || !BCrypt.Net.BCrypt.Verify(password, user.PasswordHash))
+        {
+            return Results.BadRequest(new { error = "Invalid credentials" });
+        }
+
+        var claims = new List<System.Security.Claims.Claim>
+        {
+            new(OpenIddictConstants.Claims.Subject, user.Id.ToString()),
+            new(OpenIddictConstants.Claims.Username, user.UserName)
+        };
+        var identity = new System.Security.Claims.ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await httpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new System.Security.Claims.ClaimsPrincipal(identity));
+        return Results.Ok();
+    }
+
+    public void ApplyMigrations(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        db.Database.Migrate();
+    }
+}

--- a/TheBackendCmsSolution/Modules/OpenId/TheBackendCmsSolution.Modules.OpenId.csproj
+++ b/TheBackendCmsSolution/Modules/OpenId/TheBackendCmsSolution.Modules.OpenId.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.6" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.35.0" />
+    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="5.1.0" />
+    <PackageReference Include="OpenIddict.Server.DataProtection" Version="5.1.0" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="5.1.0" />
+    <PackageReference Include="OpenIddict.Validation.DataProtection" Version="5.1.0" />
+    <PackageReference Include="OpenIddict.Validation.SystemNetHttp" Version="5.1.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.1.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Abstractions/TheBackendCmsSolution.Modules.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.ApiService/TheBackendCmsSolution.ApiService.csproj
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.ApiService/TheBackendCmsSolution.ApiService.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Modules\Content\TheBackendCmsSolution.Modules.Content.csproj" />
     <ProjectReference Include="..\Modules\Users\TheBackendCmsSolution.Modules.Users.csproj" />
     <ProjectReference Include="..\Modules\Taxonomy\TheBackendCmsSolution.Modules.Taxonomy.csproj" />
+    <ProjectReference Include="..\Modules\OpenId\TheBackendCmsSolution.Modules.OpenId.csproj" />
   </ItemGroup>
 
 </Project>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.ApiService/appsettings.json
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.ApiService/appsettings.json
@@ -7,7 +7,8 @@
   },
   "ConnectionStrings": {
     "contentdb": "Host=localhost;Port=5432;Database=contentdb;Username=postgres;Password=postgres",
-    "tenantsdb": "Host=localhost;Port=5433;Database=tenantsdb;Username=postgres;Password=postgres"
+    "tenantsdb": "Host=localhost;Port=5433;Database=tenantsdb;Username=postgres;Password=postgres",
+    "authdb": "Host=localhost;Port=5434;Database=authdb;Username=postgres;Password=postgres"
   },
   "AllowedHosts": "*"
 }

--- a/TheBackendCmsSolution/TheBackendCmsSolution.AppHost/Program.cs
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.AppHost/Program.cs
@@ -8,9 +8,13 @@ var contentDb = contentPostgres.AddDatabase("contentdb");
 var tenantsPostgres = builder.AddPostgres("tenantsdbserver").WithPgAdmin();
 var tenantsDb = tenantsPostgres.AddDatabase("tenantsdb");
 
+var authPostgres = builder.AddPostgres("authdbserver").WithPgAdmin();
+var authDb = authPostgres.AddDatabase("authdb");
+
 var apiService = builder.AddProject<Projects.TheBackendCmsSolution_ApiService>("apiservice")
                        .WithReference(contentDb)
-                       .WithReference(tenantsDb);
+                       .WithReference(tenantsDb)
+                       .WithReference(authDb);
 builder.AddProject<Projects.TheBackendCmsSolution_Web>("webfrontend")
        .WithReference(apiService);
 

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Layout/NavMenu.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Layout/NavMenu.razor
@@ -23,5 +23,10 @@
                 <span class="bi bi-puzzle" aria-hidden="true"></span> Modules
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="login">
+                <span class="bi bi-box-arrow-in-right" aria-hidden="true"></span> Login
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentItems.razor
@@ -1,5 +1,6 @@
 @page "/admin/content-items"
 @rendermode InteractiveServer
+@attribute [Authorize]
 @inject ContentApiClient Api
 
 <h1>Content Items</h1>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentTypes.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/ContentTypes.razor
@@ -1,5 +1,6 @@
 @page "/admin/content-types"
 @rendermode InteractiveServer
+@attribute [Authorize]
 @inject ContentApiClient Api
 
 <h1>Content Types</h1>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/Modules.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Admin/Modules.razor
@@ -1,5 +1,6 @@
 @page "/admin/modules"
 @rendermode InteractiveServer
+@attribute [Authorize]
 @using TheBackendCmsSolution.Modules.Abstractions
 
 <h1>Modules</h1>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Login.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Login.razor
@@ -1,0 +1,53 @@
+@page "/login"
+@inject NavigationManager Nav
+@inject IHttpClientFactory ClientFactory
+
+<h1>Login</h1>
+@if (!string.IsNullOrEmpty(error))
+{
+    <div class="alert alert-danger">@error</div>
+}
+<EditForm Model="model" OnValidSubmit="HandleLogin">
+    <DataAnnotationsValidator />
+    <div class="mb-3">
+        <label class="form-label">Username</label>
+        <InputText class="form-control" @bind-Value="model.UserName" />
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <InputText type="password" class="form-control" @bind-Value="model.Password" />
+    </div>
+    <button class="btn btn-primary" type="submit">Login</button>
+</EditForm>
+
+@code {
+    private LoginModel model = new();
+    private string? error;
+
+    private async Task HandleLogin()
+    {
+        var client = ClientFactory.CreateClient();
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["username"] = model.UserName,
+            ["password"] = model.Password
+        });
+        var response = await client.PostAsync("/auth/login", content);
+        if (response.IsSuccessStatusCode)
+        {
+            Nav.NavigateTo("/admin/content-types", true);
+        }
+        else
+        {
+            error = "Invalid credentials";
+        }
+    }
+
+    class LoginModel
+    {
+        [Required]
+        public string UserName { get; set; } = string.Empty;
+        [Required]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Login.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/Pages/Login.razor
@@ -26,7 +26,7 @@
 
     private async Task HandleLogin()
     {
-        var client = ClientFactory.CreateClient();
+        var client = ClientFactory.CreateClient("auth");
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["username"] = model.UserName,

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Components/_Imports.razor
@@ -12,3 +12,4 @@
 @using TheBackendCmsSolution.Web.Components.FieldEditors
 @using TheBackendCmsSolution.Modules.Abstractions
 @using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Authorization

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Program.cs
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Program.cs
@@ -23,6 +23,11 @@ builder.Services.AddHttpClient<ContentApiClient>(client =>
         client.BaseAddress = new("https+http://apiservice");
     });
 
+builder.Services.AddHttpClient("auth", client =>
+    {
+        client.BaseAddress = new("https+http://apiservice");
+    });
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/Program.cs
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/Program.cs
@@ -12,6 +12,12 @@ builder.Services.AddRazorComponents()
 
 builder.Services.AddOutputCache();
 
+builder.Services.AddAuthentication("Cookies").AddCookie("Cookies", options =>
+{
+    options.LoginPath = "/login";
+});
+builder.Services.AddAuthorization();
+
 builder.Services.AddHttpClient<ContentApiClient>(client =>
     {
         client.BaseAddress = new("https+http://apiservice");
@@ -30,6 +36,9 @@ app.UseHttpsRedirection();
 
 app.UseStaticFiles();
 app.UseAntiforgery();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.UseOutputCache();
 

--- a/TheBackendCmsSolution/TheBackendCmsSolution.Web/TheBackendCmsSolution.Web.csproj
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.Web/TheBackendCmsSolution.Web.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Modules\Content\TheBackendCmsSolution.Modules.Content.csproj" />
     <ProjectReference Include="..\Modules\Taxonomy\TheBackendCmsSolution.Modules.Taxonomy.csproj" />
     <ProjectReference Include="..\Modules\Users\TheBackendCmsSolution.Modules.Users.csproj" />
+    <ProjectReference Include="..\Modules\OpenId\TheBackendCmsSolution.Modules.OpenId.csproj" />
   </ItemGroup>
 
 </Project>

--- a/TheBackendCmsSolution/TheBackendCmsSolution.sln
+++ b/TheBackendCmsSolution/TheBackendCmsSolution.sln
@@ -16,6 +16,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TheBackendCmsSolution.Modul
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TheBackendCmsSolution.Modules.Users", "Modules\Users\TheBackendCmsSolution.Modules.Users.csproj", "{E68BCFC7-466E-41D4-A028-F49B8885773E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TheBackendCmsSolution.Modules.OpenId", "Modules\OpenId\TheBackendCmsSolution.Modules.OpenId.csproj", "{CB7F418B-E642-462D-B36F-7E60D50606C3}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TheBackendCmsSolution.Modules.Taxonomy", "Modules\Taxonomy\TheBackendCmsSolution.Modules.Taxonomy.csproj", "{3BD5038F-3405-4BD3-BED5-A28A00E00234}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TheBackendCmsSolution.Modules.Tenants", "Modules\Tenants\TheBackendCmsSolution.Modules.Tenants.csproj", "{68ADEA4D-A744-4B01-BEDB-83947CCF9BE7}"
@@ -55,8 +57,12 @@ Global
 		{E68BCFC7-466E-41D4-A028-F49B8885773E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E68BCFC7-466E-41D4-A028-F49B8885773E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E68BCFC7-466E-41D4-A028-F49B8885773E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E68BCFC7-466E-41D4-A028-F49B8885773E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3BD5038F-3405-4BD3-BED5-A28A00E00234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E68BCFC7-466E-41D4-A028-F49B8885773E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CB7F418B-E642-462D-B36F-7E60D50606C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CB7F418B-E642-462D-B36F-7E60D50606C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CB7F418B-E642-462D-B36F-7E60D50606C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CB7F418B-E642-462D-B36F-7E60D50606C3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3BD5038F-3405-4BD3-BED5-A28A00E00234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3BD5038F-3405-4BD3-BED5-A28A00E00234}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BD5038F-3405-4BD3-BED5-A28A00E00234}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BD5038F-3405-4BD3-BED5-A28A00E00234}.Release|Any CPU.Build.0 = Release|Any CPU


### PR DESCRIPTION
## Summary
- add OpenId module with OpenIddict server configuration and basic user login
- dockerize authentication database in AppHost
- wire up module in ApiService and Web apps
- secure admin pages with `[Authorize]` and add login page

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686c6a9908708324800584e7d98de832